### PR TITLE
fix bug with directory_rename and file_bin_rewrite

### DIFF
--- a/apifilesystem/filesystem.cpp
+++ b/apifilesystem/filesystem.cpp
@@ -407,13 +407,15 @@ namespace ngs::fs {
   bool directory_rename(string oldname, string newname) {
     std::error_code ec;
     if (!directory_exists(oldname)) return false;
-    if (!directory_exists(newname)) directory_create(newname);
     oldname = filename_remove_slash(oldname, true);
     newname = filename_remove_slash(newname, true);
+    if (!directory_exists(newname)) directory_create(filename_path(newname));
     bool result = false;
     const std::filesystem::path path1 = std::filesystem::u8path(oldname);
     const std::filesystem::path path2 = std::filesystem::u8path(newname);
-    const std::filesystem::path path3 = std::filesystem::u8path(path2.u8string().substr(0, path1.u8string().length()));
+    const std::filesystem::path path3 = std::filesystem::u8path(
+    filename_add_slash(path2.u8string(), true).substr(0, 
+    filename_add_slash(path1.u8string(), true).length()));
     if (directory_exists(oldname)) {
       if ((filename_name(path1.u8string()) != filename_name(path2.u8string()) &&
         filename_path(path1.u8string()) == filename_path(path2.u8string())) ||
@@ -645,11 +647,13 @@ namespace ngs::fs {
     #endif
     return -1;
   }
-  
+
   int file_bin_rewrite(int fd) {
     #if defined(_WIN32)
+    _lseek(fd, 0, SEEK_SET);
     return _chsize(fd, 0);
     #else
+    lseek(fd, 0, SEEK_SET);
     return ftruncate(fd, 0);
     #endif
   }

--- a/apifilesystem/filesystem.cpp
+++ b/apifilesystem/filesystem.cpp
@@ -99,6 +99,19 @@ namespace ngs::fs {
       #endif
       time_t time = modified ? info.st_mtime : info.st_atime;
       if (result == -1) return result; // failure: stat errored
+      #if defined(_WIN32)
+      struct tm timeinfo = { 0 };
+      if (localtime_s(&timeinfo, &time)) return -1;
+      switch (type) {
+        case  0: return timeinfo.tm_year + 1900;
+        case  1: return timeinfo.tm_mon  + 1;
+        case  2: return timeinfo.tm_mday;
+        case  3: return timeinfo.tm_hour;
+        case  4: return timeinfo.tm_min;
+        case  5: return timeinfo.tm_sec;
+        default: return result;
+      }
+      #else
       struct tm *timeinfo = std::localtime(&time);
       switch (type) {
         case  0: return timeinfo->tm_year + 1900;
@@ -109,9 +122,10 @@ namespace ngs::fs {
         case  5: return timeinfo->tm_sec;
         default: return result;
       }
+      #endif
       return result;
     }
-
+    
     string string_replace_all(string str, string substr, string nstr) {
       size_t pos = 0;
       while ((pos = str.find(substr, pos)) != string::npos) {
@@ -623,11 +637,11 @@ namespace ngs::fs {
     wstring wfname = widen(fname);
     FILE *fp = nullptr;
     switch (mode) {
-      case  0: { fp = _wfopen(wfname.c_str(), L"rb, ccs=UTF-8" ); break; }
-      case  1: { fp = _wfopen(wfname.c_str(), L"wb, ccs=UTF-8" ); break; }
-      case  2: { fp = _wfopen(wfname.c_str(), L"w+b, ccs=UTF-8"); break; }
-      case  3: { fp = _wfopen(wfname.c_str(), L"ab, ccs=UTF-8" ); break; }
-      case  4: { fp = _wfopen(wfname.c_str(), L"a+b, ccs=UTF-8"); break; }
+      case  0: { if (!_wfopen_s(&fp, wfname.c_str(), L"rb, ccs=UTF-8" )) break; return -1; }
+      case  1: { if (!_wfopen_s(&fp, wfname.c_str(), L"wb, ccs=UTF-8" )) break; return -1; }
+      case  2: { if (!_wfopen_s(&fp, wfname.c_str(), L"w+b, ccs=UTF-8")) break; return -1; }
+      case  3: { if (!_wfopen_s(&fp, wfname.c_str(), L"ab, ccs=UTF-8" )) break; return -1; }
+      case  4: { if (!_wfopen_s(&fp, wfname.c_str(), L"a+b, ccs=UTF-8")) break; return -1; }
       default: return -1;
     }
     if (fp) { int fd = _dup(_fileno(fp));
@@ -659,7 +673,11 @@ namespace ngs::fs {
   }
   
   int file_bin_close(int fd) {
+    #if defined(_WIN32)
+    return _close(fd);
+    #else
     return close(fd);
+    #endif
   }
   
   long file_bin_size(int fd) {


### PR DESCRIPTION
directory_rename didn't actually rename a directory, just created a new folder in for the destination argument and file_bin_rewrite did truncate the file but didn't seek back to postion zero from the beginning of the file.

these things are now fixed.